### PR TITLE
Fixed metrics privileges and improved possibilitycustomization

### DIFF
--- a/kubernetes-monitoring/mgmtagent_helm/resources/mgmtagent_kubernetes_dashboard.json
+++ b/kubernetes-monitoring/mgmtagent_helm/resources/mgmtagent_kubernetes_dashboard.json
@@ -287,7 +287,7 @@
                     }
                 },
                 {
-                    "displayName": "Pod CPU Usage",
+                    "displayName": "Container CPU Usage",
                     "savedSearchId": "OOBSS-management-dashboard-123",
                     "row": 6,
                     "column": 0,
@@ -296,21 +296,21 @@
                     "nls": {},
                     "uiConfig": {
                         "chartInfo": {
-                            "colorBy": "dimensions.containerName",
+                            "colorBy": "dimensions.container",
                             "enableCorrelation": true,
                             "group": "aggregatedDatapoints.timestamp",
-                            "series": "dimensions.containerName",
+                            "series": "dimensions.container",
                             "value": "aggregatedDatapoints.value"
                         },
-                        "defaultDataSource": "mgmtagent_kubernetes_metrics/podCpuUsage",
+                        "defaultDataSource": "mgmtagent_kubernetes_metrics/container_cpu_usage_seconds_total",
                         "internalKey": "OOBSS-management-dashboard-123",
                         "jetConfig": {
                             "dataCursor": "on",
                             "legend": {
-                                "position": "top",
+                                "position": "end",
                                 "rendered": true
                             },
-                            "stack": "off",
+                            "stack": "on",
                             "styleDefaults": {
                                 "lineWidth": 2
                             },
@@ -327,11 +327,11 @@
                     },
                     "dataConfig": [
                         {
-                            "name": "mgmtagent_kubernetes_metrics/podCpuUsage",
+                            "name": "mgmtagent_kubernetes_metrics/container_cpu_usage_seconds_total",
                             "parameters": {
                                 "compartmentId": "$(params.compartmentIdParam)",
                                 "endTime": "$(context.time.end)",
-                                "mql": "podCpuUsage[auto].groupBy(containerName).mean()",
+                                "mql": "container_cpu_usage_seconds_total[1m]{cpu = total}.groupBy(container).sum()",
                                 "namespace": "mgmtagent_kubernetes_metrics",
                                 "startTime": "$(context.time.start)"
                             },
@@ -346,7 +346,7 @@
                     }
                 },
                 {
-                    "displayName": "Pod Memory Usage",
+                    "displayName": "Container Memory Usage",
                     "savedSearchId": "OOBSS-management-dashboard-123",
                     "row": 6,
                     "column": 6,
@@ -355,21 +355,21 @@
                     "nls": {},
                     "uiConfig": {
                         "chartInfo": {
-                            "colorBy": "dimensions.containerName",
+                            "colorBy": "dimensions.container",
                             "enableCorrelation": true,
                             "group": "aggregatedDatapoints.timestamp",
-                            "series": "dimensions.containerName",
+                            "series": "dimensions.container",
                             "value": "aggregatedDatapoints.value"
                         },
-                        "defaultDataSource": "mgmtagent_kubernetes_metrics/podMemoryUsage",
+                        "defaultDataSource": "mgmtagent_kubernetes_metrics/container_memory_working_set_bytes",
                         "internalKey": "OOBSS-management-dashboard-123",
                         "jetConfig": {
                             "dataCursor": "on",
                             "legend": {
-                                "position": "top",
+                                "position": "end",
                                 "rendered": true
                             },
-                            "stack": "off",
+                            "stack": "on",
                             "styleDefaults": {
                                 "lineWidth": 2
                             },
@@ -386,11 +386,11 @@
                     },
                     "dataConfig": [
                         {
-                            "name": "mgmtagent_kubernetes_metrics/podMemoryUsage",
+                            "name": "mgmtagent_kubernetes_metrics/container_memory_working_set_bytes",
                             "parameters": {
                                 "compartmentId": "$(params.compartmentIdParam)",
                                 "endTime": "$(params.time.end)",
-                                "mql": "podMemoryUsage[auto].groupBy(containerName).mean()",
+                                "mql": "container_memory_working_set_bytes[1m].groupBy(container).sum()",
                                 "namespace": "mgmtagent_kubernetes_metrics",
                                 "startTime": "$(params.time.start)"
                             },

--- a/kubernetes-monitoring/mgmtagent_helm/templates/mgmtagent_cluster_role.yaml
+++ b/kubernetes-monitoring/mgmtagent_helm/templates/mgmtagent_cluster_role.yaml
@@ -23,6 +23,8 @@ rules:
       - get
       - list
       - watch
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
   - apiGroups:
       - metrics.k8s.io
     resources:

--- a/kubernetes-monitoring/mgmtagent_helm/templates/mgmtagent_statefulset.yaml
+++ b/kubernetes-monitoring/mgmtagent_helm/templates/mgmtagent_statefulset.yaml
@@ -31,6 +31,10 @@ spec:
               mountPath: /opt/oracle
             - name: mgmtagent-config
               mountPath: /opt/oracle/mgmtagent_config
+            {{- range $v := .Values.mgmtagent.additionalConfigMaps }}
+            - name: ext-{{ $v.name }}
+              mountPath: {{ $v.mountPath }}
+            {{- end }}
       volumes:
         - name: mgmtagent-secret
           secret:
@@ -38,6 +42,11 @@ spec:
         - name: mgmtagent-config
           configMap:
             name: mgmtagent-monitoring-config
+        {{- range $v := .Values.mgmtagent.additionalConfigMaps }}
+        - name: ext-{{ $v.name }}
+          configMap:
+            name: {{ $v.name }}
+        {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: mgmtagent-pvc

--- a/kubernetes-monitoring/mgmtagent_helm/values.yaml
+++ b/kubernetes-monitoring/mgmtagent_helm/values.yaml
@@ -2,6 +2,12 @@ mgmtagent:
    # Copy the downloaded Management Agent Install Key file under root helm directory as resources/input.rsp
    installKey: resources/input.rsp
    # Follow steps documented at https://github.com/oracle/docker-images/tree/main/OracleManagementAgent to build docker image.
+
+   # Allow user to mount additional configmap to customize management agent config json (i.e. customize prometheus collect time)
+#  additionalConfigMaps:
+#     - name: mgmt-agent-config
+#       mountPath: "/opt/oracle/mgmt_agent/agent_inst/config/destinations/OCI/services/Agent/1/types/"
+
    image:
       # Replace this value with actual docker image URL for Management Agent
       url:


### PR DESCRIPTION
We tried to deploy this to out recent OKE 1.25 but we had some issues, we overcame those issue and we want to share the solution:
1. we had to explicitly mention in the cluster role the "/metrics" endpoint for the k8s cluster otherwise we would not be able to scrape some etcd and cluster aware metrics
2. the dashboard now target the new and correct metrics for container metrics
3. we added the possibility in the values.yaml to add an array of configmaps in order to give the user the possibility to extend logging analytics images configuration (i.e. modify agent.json to change uploaded metrics)