### PR TITLE
Adding ansible playbook support to upgrade Management Agent

### DIFF
--- a/deployment/ansible-playbooks/README.md
+++ b/deployment/ansible-playbooks/README.md
@@ -7,6 +7,10 @@ The current playbooks works for linux based hosts, but this can be extended to o
 
 <br/><br/>
 ## Pre-requisites
+- Make sure ansible (version 2.9 or above version) is installed on localhost from where the deployment is initiated
+refer: https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html
+- Make sure python3 (version 3.6 or above version) is installed in all target hosts and localhost from where the deployment is initiated
+refer: https://docs.python.org/3/using/unix.html#getting-and-installing-the-latest-version-of-python
 - Make sure you have SSH capability on the target hosts and the user connecting through SSH has the capability to become root.
 - You need to have OCI CLI installed and OCI configuration created only on the localhost from where the deployment is initiated.<br/>
 refer: https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/cliinstall.htm#Quickstart
@@ -35,6 +39,11 @@ export compartment_ocid=<your_compartment_ocid_goes_here>
 ### Installing agent
 ```
 ansible-playbook -i hosts mgmt_agent_install.yaml -kK
+```
+
+### Upgrading agent
+```
+ansible-playbook -i hosts mgmt_agent_upgrade.yaml -kK
 ```
 
 ### Uninstalling agent

--- a/deployment/ansible-playbooks/README.md
+++ b/deployment/ansible-playbooks/README.md
@@ -4,10 +4,9 @@
 This provides the automated agent deployment on multiple target hosts, where monitoring is required.<br>
 Following sections will walk you through the pre-requisites, configuration and executing the playbooks.<br>
 The current playbooks works for linux based hosts, but this can be extended to other operating systems as well.
-
 <br/><br/>
 ## Pre-requisites
-- Make sure ansible (version 2.9 or above version) is installed on localhost from where the deployment is initiated
+- Make sure ansible (version 2.9 or above version) is installed on localhost from where the deployment is initiated.
 refer: https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html
 - Make sure python3 (version 3.6 or above version) is installed in all target hosts and localhost from where the deployment is initiated
 refer: https://docs.python.org/3/using/unix.html#getting-and-installing-the-latest-version-of-python
@@ -17,7 +16,6 @@ refer: https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/cliinstall.htm#Qui
 
 - You need ansible collection to execute playbooks and configured with OCI CLI on the localhost from where the deployment is initiated.<br/>
 refer: https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/ansiblegetstarted.htm#Getting_Started_with_Oracle_Cloud_Infrastructure_and_Ansible
-
 <br/><br/>
 ## Configuration
 ### Hosts file
@@ -56,8 +54,6 @@ Note:
 
 - SSH password: The ssh user password<br>
 - BECOME password[defaults to SSH password]: The password to become the root user.
-
-
 <br/><br/>
 ## Verifying the execution of playbooks
 - At the end of each playbook run, you should be able to see something similar like this for a successful execution
@@ -70,7 +66,6 @@ localhost                  : ok=12   changed=1    unreachable=0    failed=0    s
 
 - Go to oracle cloud - Observability & Management -  Management Agents - Agents
   - select the compartment and verify the installed agents
-
 <br/><br/>
 ## Copyright
 Copyright (c) 2022 Oracle and/or its affiliates.

--- a/deployment/ansible-playbooks/README.md
+++ b/deployment/ansible-playbooks/README.md
@@ -6,7 +6,7 @@ Following sections will walk you through the pre-requisites, configuration and e
 The current playbooks works for linux based hosts, but this can be extended to other operating systems as well.
 <br/><br/>
 ## Pre-requisites
-- Make sure ansible (version 2.9 or above version) is installed on localhost from where the deployment is initiated.
+- Make sure ansible (version 2.9 or above version) is installed on localhost from where the deployment is to be initiated.
 refer: https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html
 - Make sure python3 (version 3.6 or above version) is installed in all target hosts and localhost from where the deployment is initiated
 refer: https://docs.python.org/3/using/unix.html#getting-and-installing-the-latest-version-of-python

--- a/deployment/ansible-playbooks/README.md
+++ b/deployment/ansible-playbooks/README.md
@@ -6,7 +6,7 @@ Following sections will walk you through the pre-requisites, configuration and e
 The current playbooks works for linux based hosts, but this can be extended to other operating systems as well.
 <br/><br/>
 ## Pre-requisites
-- Make sure ansible (version 2.9 or above version) is installed on localhost from where the deployment is to be initiated.
+- Make sure ansible (version 2.9 or above version) is installed on localhost from where the deployment is to be initiated.            
 refer: https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html
 - Make sure python3 (version 3.6 or above version) is installed in all target hosts and localhost from where the deployment is initiated
 refer: https://docs.python.org/3/using/unix.html#getting-and-installing-the-latest-version-of-python

--- a/deployment/ansible-playbooks/mgmt_agent_upgrade.yaml
+++ b/deployment/ansible-playbooks/mgmt_agent_upgrade.yaml
@@ -1,0 +1,125 @@
+# Copyright (c) 2021, 2024 Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+# 
+---
+
+# validations
+- hosts: target_hosts
+  vars:
+    # common vars
+  tasks:
+    - name: collect facts about system services
+      service_facts:
+
+    - name: Check if the mgmt_agent service is already installed
+      fail:
+        msg: "Management Agent is not installed in the host, hence upgrade is not required"
+      when: "'mgmt_agent.service' not in services"
+          
+    - name: Check if the mgmt_agent service is in running state
+      fail:
+        msg: "Management Agent installed in the host is not in running state"
+      when: "'mgmt_agent.service' not in services or ansible_facts.services['mgmt_agent.service'].state != 'running'"
+
+# workflows
+- hosts: localhost
+  collections:
+    - oracle.oci
+  tasks:
+    - name: Check pre-requisites
+      fail:
+        msg: "Environment variable {{item}} not set. Please declare an environment variable with an appropriate value for the sample to work."
+      when: item not in ansible_env
+      with_items:
+        - "compartment_ocid"
+
+    - name: Create a directory if it does not exist
+      ansible.builtin.file:
+        path: "./{{remote_mgmt_agent_scratch_dir}}"
+        state: directory
+        mode: '0755'
+
+    - name: List Management Agent Images
+      oci_management_agent_image_facts:
+        compartment_id: "{{compartment_ocid}}"
+        install_type: AGENT
+      register: image_result
+    - set_fact:
+        object_url: "{{ item.object_url | split('/')}}"
+        namespace: "{{[4]|map('extract', item.object_url.split('/')) | join()}}"
+        bucket_name: "{{[6]|map('extract', item.object_url.split('/')) | join ()}}"
+        object_name: "{{[8,9,10]|map('extract', item.object_url.split('/')) | join('/')}}"
+        image_version: "{{ item.version }}"
+
+      with_items: "{{image_result.management_agent_images}}"
+      when:
+        - item.platform_name == "Linux-x86_64"
+        - item.package_type == "RPM"
+    - debug:
+        msg: "Extracted the agent image details as follows Namespace: {{namespace}} Bucket: {{bucket_name}} Object name: {{object_name}} Agent Image Version : {{image_version}}"
+  
+    - name: Download Agent RPM object
+      oci_object_storage_object:
+        # required
+        namespace_name: "{{namespace}}"
+        bucket_name: "{{bucket_name}}"
+        object_name: "{{object_name}}"
+        dest: "./{{remote_mgmt_agent_scratch_dir}}/oracle.mgmt_agent.rpm"
+      tags: download_agent
+ 
+- hosts: target_hosts
+  vars:
+    # common vars
+  tasks:
+    - name: Check if upgrade operation is applicable for Management Agent
+      become: yes
+      ansible.builtin.shell: /opt/oracle/mgmt_agent/agent_inst/bin/agentcore version
+      register: agent_version
+    - set_fact:
+        host_agent_version: "{{ agent_version.stdout_lines }}"
+    - debug:
+        msg: "Management Agent Version : {{host_agent_version[0]}} Agent Image Version : {{hostvars['localhost']['image_version']}}"
+    - fail:
+        msg: "Management Agent is up-to-date with latest version of software available in production"
+      when: "host_agent_version[0] >= hostvars['localhost']['image_version']"
+
+    - name: Transfer all Management Agent files over to the hosts
+      become: yes
+      become_user: root
+      copy:
+        src: "./{{remote_mgmt_agent_scratch_dir}}"
+        dest: "{{remote_mgmt_agent_scratch_parent}}"
+        owner: root
+        group: root
+        mode: '0644'
+
+    - name: Upgrade the Management Agent
+      become: yes
+      become_user: root
+      shell:
+        "rpm -U {{remote_mgmt_agent_scratch_path}}/oracle.mgmt_agent.rpm"
+      tags: upgrade-agent
+    
+    - name: Collect facts about system services
+      service_facts:
+
+    - name: Check if the mgmt_agent service is in running state
+      fail:
+        msg: "mgmt_agent is not in running state"
+      when: "'mgmt_agent.service' not in services or ansible_facts.services['mgmt_agent.service'].state != 'running'"
+    
+    - name: Cleanup Management Agent binary copied to the target host
+      become: yes
+      become_user: root
+      file:
+        path: "{{remote_mgmt_agent_scratch_path}}"
+        state: absent
+
+- hosts: localhost
+  collections:
+    - oracle.oci
+  tasks:
+    - name: Cleanup Management Agent binary downloaded in localhost
+      file:
+        path: "./{{remote_mgmt_agent_scratch_dir}}"
+        state: absent


### PR DESCRIPTION
1. Adding ansible playbook support to upgrade Management Agent
2. Updated README.md with the command to execute Management Agent upgrade